### PR TITLE
Upload Circle CI Code Coverage reports to Codecov from CircleCI

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["@babel/preset-react"],
+    "plugins": ["istanbul"]
+  }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-    "presets": ["@babel/preset-react"],
+    "presets": ["@babel/preset-react", "next/babel"],
     "plugins": ["istanbul"]
   }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
                     "http-get://localhost:3000"
                 post-steps: 
                     - store_artifacts: 
-                          path: coverage_cypress
+                          path: coverage
                     - codecov/upload
 
                 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ workflows:
                   run-command: test:ci
                   post-steps:
                       - store_artifacts:
-                            path: coverage
+                            path: coverage_jest
                       - codecov/upload
 #            - cypress-tests
             - cypress/install:
@@ -48,7 +48,7 @@ workflows:
                     "http-get://localhost:3000"
                 post-steps: 
                     - store_artifacts: 
-                          path: coverage
+                          path: coverage_cypress
                     - codecov/upload
 
                 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,8 @@ workflows:
                   run-command: test:ci
                   post-steps:
                       - store_artifacts:
-                            path: coverage_jest
+                            path: coverage
                       - codecov/upload
-#            - cypress-tests
             - cypress/install:
                 build: npm run build
             - cypress/run:

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,7 @@
 .pnp.js
 
 # testing
-/coverage_jest
-/coverage_cypress
-.babelrc
+/coverage
 .nyc_output/
 /cypress/videos
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,7 @@ const customJestConfig = {
         '!next.config.js',
     ],
     coverageReporters: ['html', 'cobertura'],
-    coverageDirectory: 'coverage_jest',
+    //coverageDirectory: 'coverage_jest',
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "personal_site_nextjs",
     "private": true,
     "nyc": {
-        "report-dir": "coverage_cypress"
+        "report-dir": "coverage"
     },
     "scripts": {
         "dev": "next dev",


### PR DESCRIPTION
Istanbul is a tool used to instrument code. This instrumentation is how code coverage reports know what areas of the code were used during a test. 

In order to instrument code for Cypress tests, we have to add Istanbul as a part of the build process. We do this in .babelrc. 

This addresses #15 . 